### PR TITLE
Remove tooling webserver from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1.102-alpine3.10 AS build
 WORKDIR /app
 
-COPY generate.sh /opt/representer/bin/
-
-# Download exercism tooling webserver
-RUN wget -P /usr/local/bin https://github.com/exercism/local-tooling-webserver/releases/latest/download/tooling_webserver && \
-    chmod +x /usr/local/bin/exercism_local_tooling_webserver
-
 # Copy fsproj and restore as distinct layers
 COPY src/Exercism.Representers.FSharp/Exercism.Representers.FSharp.fsproj ./
 RUN dotnet restore -r linux-musl-x64
@@ -21,5 +15,7 @@ WORKDIR /opt/representer
 
 COPY --from=build /opt/representer/ .
 COPY --from=build /usr/local/bin/ /usr/local/bin/
+
+COPY generate.sh /opt/representer/bin/
 
 ENTRYPOINT ["sh", "/opt/representer/bin/generate.sh"]


### PR DESCRIPTION
The tooling webserver has been obsoleted due to https://github.com/exercism/tooling-invoker/pull/29